### PR TITLE
fix custom activation example

### DIFF
--- a/examples/custom_activation.rs
+++ b/examples/custom_activation.rs
@@ -60,8 +60,8 @@ fn serde_nextgen(rewards: Vec<(AgentDNA, f32)>) -> Vec<AgentDNA> {
 }
 
 fn main() {
-    let log_activation = activation_fn!(f32::log10);
-    register_activation(log_activation);
+    let sin_activation = activation_fn!(f32::sin);
+    register_activation(sin_activation);
 
     #[cfg(not(feature = "rayon"))]
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
Changing log activation in example to sin because it doesn't return NaN unless the input is NaN. Because all evidence of NaN in https://github.com/HyperCodec/neat/issues/59 and https://github.com/HyperCodec/neat/issues/53 is from this example, it's safe to assume that they were caused by log and can be closed.